### PR TITLE
chore(npm): enforce minimum package release age

### DIFF
--- a/.npmrc 
+++ b/.npmrc 
@@ -1,0 +1,1 @@
+min-release-age=3


### PR DESCRIPTION
## Summary
- add `min-release-age=3` to npm configuration
- prevent installing packages that were published too recently
- reduce supply-chain risk from freshly published malicious packages

## Test plan
- [x] Confirm `.npmrc ` contains `min-release-age=3`
- [x] Verify branch is pushed to `origin/fix/axios-security`

close #25